### PR TITLE
[ERDE-1473] Use CentOS Stream 8 for erde-agent builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG PYTHON_VERSION=3.9.4
 WORKDIR /var/lib/refactr/agent
 
 # Install dnf packages
-#RUN dnf update -y
+RUN dnf upgrade -y
 RUN dnf install -y sudo gcc openssh openssh-clients git ca-certificates wget \
         unzip which jq python3-pip python3-devel @development zlib-devel \
         bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
-RUN sed -i -e "s|^mirrorlist=|#mirrorlist=|g" -e "s|^#baseurl=|baseurl=|g" -e "s|^baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-Linux-* &&\
-    yum upgrade -y
+RUN dnf -y update
 
 ARG RUNNER_VERSION=latest
 ARG PYENV_VERSION_BRANCH=v1.2.26

--- a/scripts/install-refactr-agent.sh
+++ b/scripts/install-refactr-agent.sh
@@ -48,15 +48,20 @@ SYSTEMD
 }
 
 function setup_centos8 {
+    # Is this CentOS Linux 8?
+    [ -f /etc/os-release ] && . /etc/os-release \
+        && [ "$ID" = 'centos' ] \
+        && [ "$VERSION_ID" = '8' ] \
+        && [ "$PRETTY_NAME" == 'CentOS Linux 8' ] \
+        && sed -i -e "s|^mirrorlist=|#mirrorlist=|g" -e "s|^#baseurl=|baseurl=|g" -e "s|^baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-Linux-* \
+        && dnf -y swap centos-linux-repos centos-stream-repos \
+        && dnf -y distro-sync
+
     # Install dnf packages
-    # https://github.com/pyenv/pyenv/wiki
-    #dnf update -y
-    sed -i -e "s|^mirrorlist=|#mirrorlist=|g" -e "s|^#baseurl=|baseurl=|g" -e "s|^baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-Linux-* \
-        && dnf upgrade -y
-        && dnf install -y gcc openssh openssh-clients git ca-certificates wget \
-            unzip which jq python3-pip python3-devel @development zlib-devel \
-            bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz \
-            xz-devel libffi-devel findutils glibc-locale-source glibc-langpack-en
+    dnf install -y gcc openssh openssh-clients git ca-certificates wget \
+        unzip which jq python3-pip python3-devel @development zlib-devel \
+        bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz \
+        xz-devel libffi-devel findutils glibc-locale-source glibc-langpack-en
 
     # Updating locales
     localedef -c -f UTF-8 -i en_US en_US.UTF-8


### PR DESCRIPTION
See also [PR# 638: [ERDE-1473] Use CentOS Stream 8 for erde-agent builds](https://github.com/sophos-factory/erde/pull/638) in `erde` repo